### PR TITLE
Modify 10 MHz out to be generated from 100 MHz ref instead of txusrclk

### DIFF
--- a/BlockDesign/zcu102_zpulse/hdl/zcu102_zpulse_wrapper.vhd
+++ b/BlockDesign/zcu102_zpulse/hdl/zcu102_zpulse_wrapper.vhd
@@ -2,7 +2,7 @@
 --Copyright 2022-2025 Advanced Micro Devices, Inc. All Rights Reserved.
 ----------------------------------------------------------------------------------
 --Tool Version: Vivado v.2025.2 (lin64) Build 6299465 Fri Nov 14 12:34:56 MST 2025
---Date        : Thu Mar 26 19:18:18 2026
+--Date        : Tue Mar 31 14:12:57 2026
 --Host        : mate running 64-bit Ubuntu 25.10
 --Command     : generate_target zcu102_zpulse_wrapper.bd
 --Design      : zcu102_zpulse_wrapper
@@ -16,6 +16,7 @@ entity zcu102_zpulse_wrapper is
   port (
     CLK_IN_300_clk_n : in STD_LOGIC;
     CLK_IN_300_clk_p : in STD_LOGIC;
+    clk_100_in : in STD_LOGIC;
     clk_10_out : out STD_LOGIC;
     clk_10mhz_in : in STD_LOGIC;
     clk_out_100 : out STD_LOGIC;
@@ -47,7 +48,8 @@ architecture STRUCTURE of zcu102_zpulse_wrapper is
     tx_data : out STD_LOGIC_VECTOR ( 511 downto 0 );
     tx_postcursor : out STD_LOGIC_VECTOR ( 39 downto 0 );
     tx_diffctrl : out STD_LOGIC_VECTOR ( 39 downto 0 );
-    tx_precursor : out STD_LOGIC_VECTOR ( 39 downto 0 )
+    tx_precursor : out STD_LOGIC_VECTOR ( 39 downto 0 );
+    clk_100_in : in STD_LOGIC
   );
   end component zcu102_zpulse;
 begin
@@ -55,6 +57,7 @@ zcu102_zpulse_i: component zcu102_zpulse
      port map (
       CLK_IN_300_clk_n => CLK_IN_300_clk_n,
       CLK_IN_300_clk_p => CLK_IN_300_clk_p,
+      clk_100_in => clk_100_in,
       clk_10_out => clk_10_out,
       clk_10mhz_in => clk_10mhz_in,
       clk_out_100 => clk_out_100,

--- a/BlockDesign/zcu102_zpulse/zcu102_zpulse.bd
+++ b/BlockDesign/zcu102_zpulse/zcu102_zpulse.bd
@@ -1,7 +1,7 @@
 {
   "design": {
     "design_info": {
-      "boundary_crc": "0x7581DF24199A2467",
+      "boundary_crc": "0x7FDF45AE27523B06",
       "device": "xczu9eg-ffvb1156-2-e",
       "name": "zcu102_zpulse",
       "rev_ctrl_bd_flag": "RevCtrlBdOff",
@@ -349,6 +349,32 @@
           "PortWidth": {
             "value": "40",
             "value_src": "ip_prop"
+          }
+        }
+      },
+      "clk_100_in": {
+        "type": "clk",
+        "direction": "I",
+        "parameters": {
+          "CLK_DOMAIN": {
+            "value": "zcu102_zpulse_clk_in1_0",
+            "value_src": "default"
+          },
+          "FREQ_HZ": {
+            "value": "100000000",
+            "value_src": "default"
+          },
+          "FREQ_TOLERANCE_HZ": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "INSERT_VIP": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "PHASE": {
+            "value": "0.0",
+            "value_src": "default"
           }
         }
       }
@@ -2599,6 +2625,12 @@
           "PSU__IRQ_P2F_UART1__INT": {
             "value": "0"
           },
+          "PSU__IRQ_P2F_USB2_OTG__INT0": {
+            "value": "0"
+          },
+          "PSU__IRQ_P2F_USB2_OTG__INT1": {
+            "value": "0"
+          },
           "PSU__IRQ_P2F_USB3_ENDPOINT__INT0": {
             "value": "0"
           },
@@ -3674,10 +3706,10 @@
         "has_run_ip_tcl": "true",
         "parameters": {
           "CLKIN1_JITTER_PS": {
-            "value": "40.0"
+            "value": "100.0"
           },
           "CLKOUT1_JITTER": {
-            "value": "450.501"
+            "value": "460.700"
           },
           "CLKOUT1_PHASE_ERROR": {
             "value": "523.418"
@@ -3689,22 +3721,22 @@
             "value": "92.375"
           },
           "MMCM_CLKIN1_PERIOD": {
-            "value": "4.000"
+            "value": "10.000"
           },
           "MMCM_CLKIN2_PERIOD": {
-            "value": "10.0"
+            "value": "10.000"
           },
           "MMCM_CLKOUT0_DIVIDE_F": {
             "value": "92.375"
           },
           "MMCM_DIVCLK_DIVIDE": {
-            "value": "25"
+            "value": "10"
           },
           "OPTIMIZE_CLOCKING_STRUCTURE_EN": {
             "value": "true"
           },
           "PRIM_IN_FREQ": {
-            "value": "250"
+            "value": "100"
           },
           "USE_LOCKED": {
             "value": "false"
@@ -10913,6 +10945,12 @@
           "clk_wiz_2/clk_in1"
         ]
       },
+      "clk_in1_0_2": {
+        "ports": [
+          "clk_100_in",
+          "clk_wiz_1/clk_in1"
+        ]
+      },
       "clk_wiz_0_clk_out1": {
         "ports": [
           "clk_wiz_0/clk_out1",
@@ -11004,7 +11042,6 @@
       "s_axi_aclk_0_1": {
         "ports": [
           "txusr_in",
-          "clk_wiz_1/clk_in1",
           "proc_sys_reset_0/slowest_sync_clk",
           "tx_channels/txusr_in"
         ]

--- a/Sources/top_zcu102_zpulse.vhd
+++ b/Sources/top_zcu102_zpulse.vhd
@@ -149,6 +149,7 @@ begin
             txusr_in            => w_txusrclk2,
             clk_10_out          => w_clk_10_out,
             clk_10mhz_in        => clk_10mhz_in,
+            clk_100_in          => w_clk_to_gt,
             ext_clk_locked      => w_ext_clk_locked,
             tx_data             => tx_data,
             tx_inhibit          => tx_inhibit,


### PR DESCRIPTION
Fixed by changing the clock reference for the 10 MHz to be the REFCLK of 100 MHz instead of the txusrclk